### PR TITLE
No issue: adapt focus-android contributing documentation

### DIFF
--- a/android/CONTRIBUTING.md
+++ b/android/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to Focus/Klar for Android
+
+Thank you for taking the time to contribute to 🔥 🦊 Focus/Klar! 🎉 👍  
+
+## Filing bugs
+
+* 📱 Please include the Android device and Android version you are using 
+* 🌐 Posting [your user agent](https://duckduckgo.com/?q=my+user+agent) can
+  help us debug problems.
+* 📓 Include a list of steps to reproduce the issue
+* 🔬 State what behavior you expected and what the actual behavior is on your
+  device
+
+## Writing code
+
+* Start by looking for issues marked with the [`good first issue`
+  label](https://github.com/mozilla-mobile/focus-android/labels/good%20first%20issue)
+* You can find more challenging issues marked with the [`help wanted`
+  label](https://github.com/mozilla-mobile/focus-android/labels/help%20wanted)
+* Join the #focus channel on [irc.mozilla.org](https://wiki.mozilla.org/IRC)
+  and get in contact with us. We're available Monday-Friday, during GMT and PST
+working hours.
+* Comment on the issue if you would like to work on it.
+* If you want to work on a new feature then always file an issue first so that
+  all teams (product, ux, engineering) can comment on it and so that it can be
+assigned to a milestone. **Pull requests for unsolicited features are unlikely
+to get merged.**
+* When you open a pull request, please also include a screenshot if there are
+  UI changes, so UX can also do a visual review.
+* Include a `Closes #<issue-number>` as part of your first commit message so
+  it's auto-linked to the issue.
+
+## Translating the app
+
+* Get in touch with the [existing localization
+  team](https://wiki.mozilla.org/L10n:Teams).
+* Localization happens on
+  [Pontoon](https://pontoon.mozilla.org/projects/focus-for-android/).
+
+## Testing the app
+
+* Download Focus and test the app. Or [sign up to get beta
+  builds](https://github.com/mozilla-mobile/focus-android/wiki/Beta) from
+Google Play.
+* File [new issues](https://github.com/mozilla-mobile/focus-android/issues) for
+  all bugs you encounter. Make sure that an issue isn't filed already (via the
+search).
+* Make sure that your bug report contains: Android version, device name, exact
+  steps to reproduce the issue, a description of what you expect and what
+actually happens.
+* Try to reproduce issues reported by others and add additional or missing
+  information to the bug reports.

--- a/android/CONTRIBUTING.md
+++ b/android/CONTRIBUTING.md
@@ -1,52 +1,113 @@
-# Contributing to Focus/Klar for Android
+# Contributing to Mozilla Mobile's Android projects
 
-Thank you for taking the time to contribute to 🔥 🦊 Focus/Klar! 🎉 👍  
+Thank you for taking the time to contribute to one of Mozilla's Android
+projects! 🔥 🦊 <3 🤖! 🎉 👍 For a full list of projects, see
+[the README](../README.md#android).
 
-## Filing bugs
+Before contributing, please review our [Community Participation Guidelines].
 
-* 📱 Please include the Android device and Android version you are using 
-* 🌐 Posting [your user agent](https://duckduckgo.com/?q=my+user+agent) can
-  help us debug problems.
-* 📓 Include a list of steps to reproduce the issue
-* 🔬 State what behavior you expected and what the actual behavior is on your
-  device
+We welcome all types of contributions, including, but not limited to:
+* [Filing issues](#filing-issues)
+* [Translating our apps](#translating-our-apps)
+* [User experience design](#user-experience-design)
+* [Writing documentation](#documentation)
+* [Testing the app](#testing-the-app)
+* [Writing code](#writing-code)
 
-## Writing code
+Have another idea for how you can contribute? Let us know!
 
-* Start by looking for issues marked with the [`good first issue`
-  label](https://github.com/mozilla-mobile/focus-android/labels/good%20first%20issue)
-* You can find more challenging issues marked with the [`help wanted`
-  label](https://github.com/mozilla-mobile/focus-android/labels/help%20wanted)
-* Join the #focus channel on [irc.mozilla.org](https://wiki.mozilla.org/IRC)
-  and get in contact with us. We're available Monday-Friday, during GMT and PST
-working hours.
-* Comment on the issue if you would like to work on it.
-* If you want to work on a new feature then always file an issue first so that
-  all teams (product, ux, engineering) can comment on it and so that it can be
-assigned to a milestone. **Pull requests for unsolicited features are unlikely
-to get merged.**
-* When you open a pull request, please also include a screenshot if there are
-  UI changes, so UX can also do a visual review.
-* Include a `Closes #<issue-number>` as part of your first commit message so
-  it's auto-linked to the issue.
+### Communication
+For each our projects, we communicate with the project's:
+- Issues tracker
+- Mailing list
+- [IRC](https://wiki.mozilla.org/IRC) channel. *We're available Monday-Friday
+during GMT and PST working hours.*
 
-## Translating the app
+**Be sure to join them** and don't be afraid to make postings of your
+own! A link to each project-specific communication channel can be found in
+the project's README.
+
+## Filing issues
+
+We usually track our project's issues on GitHub (example: [focus-android][fa issues]).
+To file a bug:
+* Find your project's issues: these will be linked from the project's README
+or you can click directly into the issues from the project's home page
+* Create a new issue!
+
+To ensure we can understand, reproduce, and effectively triage your issues,
+**please fill out the provided template** when filing an issue! When issues
+are filed in a consistent style and include the information we need to
+make decisions, we're more likely to take action on these issues than if
+we don't understand them.
+
+*Be sure to include any extra information you find valuable!* For example, posting
+[your user agent](https://duckduckgo.com/?q=my+user+agent) can help us debug problems.
+
+## Translating our apps
 
 * Get in touch with the [existing localization
   team](https://wiki.mozilla.org/L10n:Teams).
 * Localization happens on
   [Pontoon](https://pontoon.mozilla.org/projects/focus-for-android/).
 
+## User experience design
+
+Get in touch with one of our designers (@brampitoyo or @aminalhazwani)
+or other core team members to get involved! With a limited number of engineers, we
+can't implement every design so we want to make sure any design work you do will
+make it into our products.
+
+## Writing documentation
+
+### Product support documentation
+Each Mozilla product provides in-app support. This documentation can be found on
+[support.mozilla.org][sumo]. If you wish to contribute, please contact a core team
+member to get started.
+
+### Developer/repository documentation
+See an issue with our documentation, either in a project's repository or this
+`shared-docs` repository? Please file an issue or create a pull request
+to fix it yourself!
+
 ## Testing the app
 
-* Download Focus and test the app. Or [sign up to get beta
-  builds](https://github.com/mozilla-mobile/focus-android/wiki/Beta) from
-Google Play.
-* File [new issues](https://github.com/mozilla-mobile/focus-android/issues) for
-  all bugs you encounter. Make sure that an issue isn't filed already (via the
-search).
-* Make sure that your bug report contains: Android version, device name, exact
-  steps to reproduce the issue, a description of what you expect and what
-actually happens.
+* Download one of our products and look for issues. Some products have pre-release
+Beta builds: check out their READMEs to download them!
+* File [new issues](#filing-issues) for all bugs you encounter. Make sure that an
+issue isn't filed already (via the search).
+* Make sure that your bug report follows the provided template
 * Try to reproduce issues reported by others and add additional or missing
-  information to the bug reports.
+information to the bug reports.
+
+## Writing code
+
+**New to Mozilla's mobile projects?** See issues labeled `good first issue` in your project's
+issues tracker (example: [focus-android][fa good first]). These are designed to be
+easier to implement so you can focus on learning our pull request workflow. *Please only
+fix one of these.*
+
+**Looking for more challenging issues?** See issues labeled `help wanted` (example:
+[focus-android][fa help]). These are issues that are ready to be implemented without
+additional product or UX discussion.
+
+If you run into trouble, ask for help! Check out our
+[preferred communication channels.](#communication)
+
+When writing code:
+* **Comment on an issue if you would like to work on it.** This ensures it is still
+available for you to work on
+* If you want to work on a new feature then *always file an issue first* and wait
+for our team to discuss it. We want to ensure all teams (product, ux, engineering)
+have an opportunity to provide feedback. **Pull requests for unsolicited features
+are unlikely to get merged.**
+* When you open a pull request, please also include a screenshot if there are
+UI changes, so UX can also do a visual review.
+* Include a `Closes #<issue-number>` as part of your first commit message so
+it's auto-linked to the issue.
+
+[Community Participation Guidelines]: https://www.mozilla.org/en-US/about/governance/policies/participation/
+[fa issues]: https://github.com/mozilla-mobile/focus-android/issues
+[fa good first]: https://github.com/mozilla-mobile/focus-android/labels/good%20first%20issue
+[fa help]: https://github.com/mozilla-mobile/focus-android/labels/help%20wanted
+[sumo]: https://support.mozilla.org/en-US/


### PR DESCRIPTION
This is intended to replace project specific docs like https://github.com/mozilla-mobile/focus-android/wiki/Contributing