### PR TITLE
Closes #17: add docs for our sprint workflow

### DIFF
--- a/android/sprint_process.md
+++ b/android/sprint_process.md
@@ -20,7 +20,7 @@ The full team will go through newly filed issues to:
 
 Each project should link to its own triage queries (example: [focus-android](https://github.com/mozilla-mobile/focus-android/issues?q=is%3Aissue+is%3Aopen+-label%3AP1+-label%3AP2+-label%3AP3+-label%3AP4+-label%3AP5+-label%3Aaddressed+-label%3Ablocked+sort%3Aupdated-desc+no%3Amilestone)).
 
-For more information on priority labels, [see below](#issue-naming-and-labels).
+For more information on priority labels, [see below](#categorizing-issues).
 
 ### Bug management (weekly)
 The full team meets to manage bugs. This meeting time-slot alternates between two separate agendas:
@@ -37,23 +37,22 @@ Held mid-sprint, in this meeting we:
 - Check in on current sprint progress
 - Look over the upcoming sprint
 
-## Issue naming and labels
+## Categorizing issues
+We have several conventions for categorizing our issues.
 
 ### Labels
-Priority labels are based on the [Bugzilla triage process][triage priority] and set during triage to determine when they'll be worked on:
-* `P1`: Issues for the current 2-week sprint.
-  * [Open engineering issues](https://github.com/mozilla-mobile/focus-android/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3AP1%20NOT%20%5Bux%5D%20in%3Atitle%20)
-  * [Open UX issues](https://github.com/mozilla-mobile/focus-android/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3AP1%20ux%20in%3Atitle%20)
-* `P2`: Issues for the 6-week milestone release.
-  * [Open engineering issues](https://github.com/mozilla-mobile/focus-android/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3AP2%20NOT%20%5Bux%5D%20in%3Atitle%20)
-  * [Open UX issues](https://github.com/mozilla-mobile/focus-android/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3AP2%20ux%20in%3Atitle%20)
+We label issues with their priority: these priorities are based on the [Bugzilla triage process][triage priority].
+* `P1`: issues for the current 2-week sprint
+* `P2`: issues for the 6-week milestone release
 * `P3`: Backlog
 * `P5`: Will not fix but will accept a patch
 
 Other labels:
-* `addressed`: Label for excluding items from triage. Should be used for [meta] items.
+* `addressed`: label for excluding items from triage. Should be used for [meta] items.
 
 ### Issue Prefixes
+In the issue title, we may prefix the name to categorize the issues.
+
 * `[meta]`: larger issues that need to be broken down, into a `[breakdown]` issue and issues for its smaller parts. This should include a checklist of all the issues (including the `[breakdown]` issue).
 
     These do NOT get a P* label, but should be in a milestone.

--- a/android/sprint_process.md
+++ b/android/sprint_process.md
@@ -3,6 +3,40 @@ Projects created by the Android Product Team typically ship a major release ever
 
 Development is broken down into two week-long chunks of time called sprints: we track the work for these sprints in GitHub milestones (example: [focus-android][milestone example]). We have several planning meetings to identify what should go into each release and thus into each sprint.
 
+## Sprint planning meetings
+### Roadmap (monthly)
+The product team plans and prioritizes the project roadmap: the general project plan over the next few months. These meetings will:
+- At a high level, decide which features go into which releases
+- Schedule team work weeks
+- Modify the release schedule (if necessary)
+
+Updates from this meeting will be emailed to the full team.
+
+### Triage (weekly)
+The full team will go through newly filed issues to:
+- Assign priority labels (P1, P2, ...) to bugs without priority labels or the `addressed` label
+- Ensure all P1 labels are assigned to a milestone
+- Ensure all P2 labels are assigned to a milestone
+
+Each project should link to its own triage queries (example: [focus-android](https://github.com/mozilla-mobile/focus-android/issues?q=is%3Aissue+is%3Aopen+-label%3AP1+-label%3AP2+-label%3AP3+-label%3AP4+-label%3AP5+-label%3Aaddressed+-label%3Ablocked+sort%3Aupdated-desc+no%3Amilestone)).
+
+For more information on priority labels, [see below](#issue-naming-and-labels).
+
+### Bug management (weekly)
+The full team meets to manage bugs. This meeting time-slot alternates between two separate agendas:
+
+#### Sprint planning
+Held before a sprint begins, in this meeting we:
+- Decide what goes into the current sprint by promoting P2 issues to P1
+- Decide what goes into the next sprint by adding issues to the upcoming milestone and setting them as P2
+
+#### Backlog grooming
+Held mid-sprint, in this meeting we:
+- Handle triage overflow
+- Add to the contributor bug lists (e.g. `help wanted`)
+- Check in on current sprint progress
+- Look over the upcoming sprint
+
 ## Issue naming and labels
 
 ### Labels
@@ -25,24 +59,5 @@ Other labels:
     These do NOT get a P* label, but should be in a milestone.
 * `[breakdown]`: issue to track the work of breaking down a larger bug
 
-## Triage - Weekly
-- ([Link](https://github.com/mozilla-mobile/focus-android/issues?q=is%3Aissue+is%3Aopen+-label%3AP1+-label%3AP2+-label%3AP3+-label%3AP4+-label%3AP5+-label%3Aaddressed+-label%3Ablocked+sort%3Aupdated-desc+no%3Amilestone)) Assign priority labels (P1, P2, ...) to bugs without priority labels or the `addressed` label
-- ([Link](https://github.com/mozilla-mobile/focus-android/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3AP1+no%3Amilestone+)) Ensure all P1 labels are assigned a milestone
-- ([Link](https://github.com/mozilla-mobile/focus-android/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3AP2+no%3Amilestone+)) Ensure all P2 labels are assigned a milestone
-
-## Weekly Bug management (alternating)
-
-### Sprint planning
-Deciding what goes into a sprint, promote P2 issues to P1. After every release, this meeting is for deciding what goes into the upcoming milestone - add issues to the milestone and set them as P2.
-
-### Backlog grooming
-Handling Triage overflow, adding to the contributor bug lists, looking at milestone lists.
-
 [triage priority]: https://wiki.mozilla.org/Bugmasters/Process/Triage#Weekly_or_More_Frequently_.28depending_on_the_component.29
-## Monthly Roadmap Planning
-Plan and prioritize features for upcoming milestones - an update will be emailed out.
-
-Plan and facilitate workweeks
-release schedule
-trying to work with things without proper training
-too much observing
+[milestone example]: https://github.com/mozilla-mobile/focus-android/milestone/30?closed=1

--- a/android/sprint_process.md
+++ b/android/sprint_process.md
@@ -1,0 +1,46 @@
+# APT sprint process
+Focus follows a 2-week sprint cycle with 6-week milestone releases. Dot-releases with bugfixes are released every two weeks. Our upcoming train schedule is [here](https://wiki.mozilla.org/Mobile/Focus/Android/Train_Schedule).
+
+## Issue naming and labels
+
+### Labels
+Priority labels are based on the [Bugzilla triage process][triage priority] and set during triage to determine when they'll be worked on:
+* `P1`: Issues for the current 2-week sprint.
+  * [Open engineering issues](https://github.com/mozilla-mobile/focus-android/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3AP1%20NOT%20%5Bux%5D%20in%3Atitle%20)
+  * [Open UX issues](https://github.com/mozilla-mobile/focus-android/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3AP1%20ux%20in%3Atitle%20)
+* `P2`: Issues for the 6-week milestone release.
+  * [Open engineering issues](https://github.com/mozilla-mobile/focus-android/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3AP2%20NOT%20%5Bux%5D%20in%3Atitle%20)
+  * [Open UX issues](https://github.com/mozilla-mobile/focus-android/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20label%3AP2%20ux%20in%3Atitle%20)
+* `P3`: Backlog
+* `P5`: Will not fix but will accept a patch
+
+Other labels:
+* `addressed`: Label for excluding items from triage. Should be used for [meta] items.
+
+### Issue Prefixes
+* `[meta]`: larger issues that need to be broken down, into a `[breakdown]` issue and issues for its smaller parts. This should include a checklist of all the issues (including the `[breakdown]` issue).
+
+    These do NOT get a P* label, but should be in a milestone.
+* `[breakdown]`: issue to track the work of breaking down a larger bug
+
+## Triage - Weekly
+- ([Link](https://github.com/mozilla-mobile/focus-android/issues?q=is%3Aissue+is%3Aopen+-label%3AP1+-label%3AP2+-label%3AP3+-label%3AP4+-label%3AP5+-label%3Aaddressed+-label%3Ablocked+sort%3Aupdated-desc+no%3Amilestone)) Assign priority labels (P1, P2, ...) to bugs without priority labels or the `addressed` label
+- ([Link](https://github.com/mozilla-mobile/focus-android/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3AP1+no%3Amilestone+)) Ensure all P1 labels are assigned a milestone
+- ([Link](https://github.com/mozilla-mobile/focus-android/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+label%3AP2+no%3Amilestone+)) Ensure all P2 labels are assigned a milestone
+
+## Weekly Bug management (alternating)
+
+### Sprint planning
+Deciding what goes into a sprint, promote P2 issues to P1. After every release, this meeting is for deciding what goes into the upcoming milestone - add issues to the milestone and set them as P2.
+
+### Backlog grooming
+Handling Triage overflow, adding to the contributor bug lists, looking at milestone lists.
+
+[triage priority]: https://wiki.mozilla.org/Bugmasters/Process/Triage#Weekly_or_More_Frequently_.28depending_on_the_component.29
+## Monthly Roadmap Planning
+Plan and prioritize features for upcoming milestones - an update will be emailed out.
+
+Plan and facilitate workweeks
+release schedule
+trying to work with things without proper training
+too much observing

--- a/android/sprint_process.md
+++ b/android/sprint_process.md
@@ -22,7 +22,7 @@ Each project should link to its own triage queries (example: [focus-android](htt
 
 For more information on priority labels, [see below](#categorizing-issues).
 
-### Bug management (weekly)
+### Weekly bug planning (weekly)
 The full team meets to manage bugs. This meeting time-slot alternates between two separate agendas:
 
 #### Sprint planning

--- a/android/sprint_process.md
+++ b/android/sprint_process.md
@@ -1,5 +1,7 @@
 # APT sprint process
-Focus follows a 2-week sprint cycle with 6-week milestone releases. Dot-releases with bugfixes are released every two weeks. Our upcoming train schedule is [here](https://wiki.mozilla.org/Mobile/Focus/Android/Train_Schedule).
+Projects created by the Android Product Team typically ship a major release every six weeks and ship a minor release twice between major releases (every two weeks). For example, if v2.0 is released on week 0, v2.1 will be released on week 2, v2.2 will be released on week 4, and v3.0 will be released on week 6. Emergency bug fixes can be released more frequently. Projects will typically link to their release schedule (example: [focus-android](https://wiki.mozilla.org/Mobile/Focus/Android/Train_Schedule)).
+
+Development is broken down into two week-long chunks of time called sprints: we track the work for these sprints in GitHub milestones (example: [focus-android][milestone example]). We have several planning meetings to identify what should go into each release and thus into each sprint.
 
 ## Issue naming and labels
 


### PR DESCRIPTION
This is intended to replace project specific pages like https://github.com/mozilla-mobile/focus-android/wiki/Sprint-Process

I'll add the triage queries to another place on those wikis.