### PR TITLE
Prefer the `For #..` syntax instead of `Closes #..` in naming patches

### DIFF
--- a/android/CONTRIBUTING_code.md
+++ b/android/CONTRIBUTING_code.md
@@ -50,7 +50,7 @@ Our team follows [the GitHub pull request workflow][gh workflow]: fork, branch, 
 pull request, automated tests, review, merge. If you're new to GitHub, check out [the official
 guides][gh guides] for more information.
 
-An example commit message summary looks like, `Closes #5: Upgrade gradle to v1.3.0`.
+An example commit message summary looks like, `For #5: Upgrade gradle to v1.3.0`.
 
 Please follow these guidelines for your pull requests:
 
@@ -65,6 +65,8 @@ the issue you're fixing.*
 intended to fix.
   - If your PR closes an issue, include `Closes #...` in one of your commit messages. This
   will automatically close the linked issue ([more info][auto close]).
+  - If your PR has to go through a longer process, for example QA verification, use the 
+  `For #...` syntax to allow the linked issue to be closed at a later, more appropriate time.
 - Prefer "micro commits".
   - A micro commit is a small commit that generally changes one thing.
   A single Pull Request may comprise of multiple incremental micro commits.


### PR DESCRIPTION
There are projects for which the `Closes #..` syntax may break the process.
For example on Fenix tickets are to be closed by QA only after verifying the
patches.
`Closes #..` should only be used when we know for a fact that we want the issue
be closed automatically after the PR merge.

For external contributors, new to Mozilla projects the default patches naming
should use the `For #..` syntax.
It's easy to manually close the ticket after the PR merge if needed and so
prevent adding to the ticket history unnecessarily closes and reopenings when
the issue should've not be automatically closed.