### PR TITLE
No issue: change code owner.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-* @mcomella
+* @MatthewTighe


### PR DESCRIPTION
I want to transfer ownership of this repository because I am no longer
active on mobile features. I asked MatthewTighe and they agreed.

Using code owners isn't strictly necessary but it seemed like the first
logical step. I use code owners to 1) get notified of new documents so I
can find reviewers and 2) so that contributors can see who to contact if
they questions about the repository.