### PR TITLE
Update the Java path in Android Studio

### DIFF
--- a/android/configure_java.md
+++ b/android/configure_java.md
@@ -14,15 +14,19 @@ Caveat: Robolectric warns that Java 9 is needed for certain functionality. This 
 ### Method #1: configure Java 8 from Android Studio
 Do the following:
 * Download and install Android Studio
-* Add the following line to your `~/.zshrc` or equivalent shell startup file: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jre/jdk/Contents/Home"`
+* Add the following line to your `~/.zshrc` or equivalent shell startup file: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`
   * Update the path if you installed Android Studio to a non-standard location
 
 That's it! To verify correctness, open a new shell, navigate to a directory with Android source code, and type `./gradlew tasks`.
 
 This works because macOS comes with a `/usr/bin/java` stub which will defer the location of the JDK to the value in the `JAVA_HOME` environment variable.
 
-### Method #2: install Java 8 from homebrew
-TODO
+### Method #2: install Java 11 from Homebrew
+You can install Java from [Homebrew]([url](https://brew.sh/)) using the command below.
+
+```bash
+brew install java11
+```
 
 ### Method #3: install from website
 TODO


### PR DESCRIPTION
Added some simple instructions for installing Java 11 on Homebrew as well.

`/Applications/Android Studio.app/Contents/jdk/Contents/Home` - current
`/Applications/Android Studio.app/Contents/jbr/Contents/Home` - next release

Instead of updating the docs to the current path, I've updated them to the path that is currently in Canary (Android Studio Electric Eel | 2022.1.1) to avoid having to update the docs again