### PR TITLE
Use astericks to find the right dir for JAVA_HOME

### DIFF
--- a/android/configure_java.md
+++ b/android/configure_java.md
@@ -14,7 +14,7 @@ Caveat: Robolectric warns that Java 9 is needed for certain functionality. This 
 ### Method #1: configure Java 8 from Android Studio
 Do the following:
 * Download and install Android Studio
-* Add the following line to your `~/.zshrc` or equivalent shell startup file: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`
+* Add the following line to your `~/.zshrc` or equivalent shell startup file: `export JAVA_HOME="/Applications/Android Studio.app/Contents/**/Contents/Home"`
   * Update the path if you installed Android Studio to a non-standard location
 
 That's it! To verify correctness, open a new shell, navigate to a directory with Android source code, and type `./gradlew tasks`.


### PR DESCRIPTION
Just thought of a better way to reference the path the internal JDK without needing to know what the immediate directory or sub-directory is. This would work for the current path for the JDK and the future paths mentioned in https://github.com/mozilla-mobile/shared-docs/pull/114 that would come in from future releases. 

@kycn what do you think?