### PR TITLE
Add Instructions on Installing Java from Oracle Website

### DIFF
--- a/android/configure_java.md
+++ b/android/configure_java.md
@@ -38,7 +38,7 @@ Installing the JDK:
 * Download the package named `jdk-8u341-macosx-x64.dmg`. Oracle requires you to
   make an account in order to install the JDK. Follow the instructions and
   confirm your email.
-* Open your `.dmg` install and follow the installation wizard.
+* Launch your `.dmg` installer and follow the installation wizard.
 * Add the following line to your `~/.zshrc` or equivalent shell startup file: `export JAVA_HOME=$(/usr/libexec/java_home)`
 
 That's it! As explained in Method #1, `$JAVA_HOME` is the environment variable

--- a/android/configure_java.md
+++ b/android/configure_java.md
@@ -30,7 +30,7 @@ brew install java11
 
 ### Method #3: install from website
 You can install Java from
-[Oracle]([url](https://www.oracle.com/java/technologies/downloads/#java8-mac))
+[Oracle](https://www.oracle.com/java/technologies/downloads/#java8-mac)
 using this link.
 
 Installing the JDK:

--- a/android/configure_java.md
+++ b/android/configure_java.md
@@ -48,6 +48,11 @@ in UNIX environments that points to your JDK installation.
 `/usr/libexec/java_home` is a symbolic link that points to matching Java VMs
 installed in your environment.
 
+If you are having trouble, please make sure to read this [Java
+Doc](https://www.java.com/en/download/help/mac_install.html) on how to install
+Java on your machine. Although this documentation highlights how to install the
+JRE, installing the JDK follows the same steps.
+
 ## Troubleshooting
 ### Get Java version
 To see what version of Java you have installed, run:

--- a/android/configure_java.md
+++ b/android/configure_java.md
@@ -29,7 +29,20 @@ brew install java11
 ```
 
 ### Method #3: install from website
-TODO
+You can install Java from
+[Oracle]([url](https://www.oracle.com/java/technologies/downloads/#java8-mac))
+using this link.
+
+Installing the JDK:
+* Navigate to `Java SE Development Kit 8u341` and click `macOS`.
+* Download the package named `jdk-8u341-macosx-x64.dmg`. Oracle requires you to
+  make an account in order to install the JDK. Follow the instructions and
+  confirm your email.
+* Open your `.dmg` install and follow the installation wizard.
+* Add the following line to your `~/.zshrc` or equivalent shell startup file: `export JAVA_HOME="/Library/Java/JavaVirtualMachines/jdk1.8.0_341.jdk/Contents/Home"`
+
+That's it! As explained in Method #1, `$JAVA_HOME` is the environment variable
+for UNIX environments that points to your JDK installation.
 
 ## Troubleshooting
 ### Get Java version

--- a/android/configure_java.md
+++ b/android/configure_java.md
@@ -41,7 +41,8 @@ Installing the JDK:
 * Launch your `.dmg` installer and follow the installation wizard.
 * Add the following line to your `~/.zshrc` or equivalent shell startup file: `export JAVA_HOME=$(/usr/libexec/java_home)`
 
-That's it! As explained in Method #1, `$JAVA_HOME` is the environment variable
+That's it! To verify correctness, open a new shell, navigate to a directory with Android source code, and type `./gradlew tasks`.
+As explained in Method #1, `$JAVA_HOME` is the environment variable
 in UNIX environments that points to your JDK installation.
 `/usr/libexec/java_home` is a symbolic link that points to matching Java VMs
 installed in your environment.

--- a/android/configure_java.md
+++ b/android/configure_java.md
@@ -42,6 +42,7 @@ Installing the JDK:
 * Add the following line to your `~/.zshrc` or equivalent shell startup file: `export JAVA_HOME=$(/usr/libexec/java_home)`
 
 That's it! To verify correctness, open a new shell, navigate to a directory with Android source code, and type `./gradlew tasks`.
+
 As explained in Method #1, `$JAVA_HOME` is the environment variable
 in UNIX environments that points to your JDK installation.
 `/usr/libexec/java_home` is a symbolic link that points to matching Java VMs

--- a/android/configure_java.md
+++ b/android/configure_java.md
@@ -39,10 +39,12 @@ Installing the JDK:
   make an account in order to install the JDK. Follow the instructions and
   confirm your email.
 * Open your `.dmg` install and follow the installation wizard.
-* Add the following line to your `~/.zshrc` or equivalent shell startup file: `export JAVA_HOME="/Library/Java/JavaVirtualMachines/jdk1.8.0_341.jdk/Contents/Home"`
+* Add the following line to your `~/.zshrc` or equivalent shell startup file: `export JAVA_HOME=$(/usr/libexec/java_home)`
 
 That's it! As explained in Method #1, `$JAVA_HOME` is the environment variable
-for UNIX environments that points to your JDK installation.
+in UNIX environments that points to your JDK installation.
+`/usr/libexec/java_home` is a symbolic link that points to matching Java VMs
+installed in your environment.
 
 ## Troubleshooting
 ### Get Java version


### PR DESCRIPTION
I was following steps on installing the correct version of Java, and found that this document needed completion.

Added instructions on installing Java from website in `android/configure_java.md`. Previously, `Method #3: install from website` was marked "TODO".

Simply, the instructions follow these steps:
1. Download the Java 8 JDK package from Oracle Downloads
2. Launch the package and install Java on macOS
3. Make `$JAVA_HOME` env variable point to the JDK install by adding it to shell startup file

I also added a link to Java Docs on installing Java to macOS, if users still have trouble.