### PR TITLE
Update Android Newsletters

### DIFF
--- a/android/android_guide.md
+++ b/android/android_guide.md
@@ -20,7 +20,7 @@ If you like staying up-to-date on the latest Android topics, members of our team
   - [Official Android developer blog](https://android-developers.googleblog.com/) (also has a newsletter)
 - Subscribing to weekly newsletters
   - [Android weekly](https://androidweekly.net/)
-  - [Android dev digest](https://www.androiddevdigest.com/)
+  - [Jetpack Compose Newsletter by Commonsware](https://jetc.dev/)
 - Listening to podcasts
   - [Fragmented](http://fragmentedpodcast.com/)
   - [Android Developers Backstage](https://androidbackstage.blogspot.com/)


### PR DESCRIPTION
While reading the docs, noticed that the newsletters could be updated:
- Removed android dev digest newsletter as it's not active anymore
- Added [Jetpack compose newsletter by commonsware](https://jetc.dev/) - good resource for all things Compose.